### PR TITLE
Add error raise on invalid path

### DIFF
--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -175,6 +175,7 @@ defmodule Plug.Static do
 
       if invalid_path?(segments) do
         Logger.error("Got invalid path: #{inspect(segments)}")
+        raise InvalidPathError, "invalid path for static asset: #{conn.request_path}"
       end
 
       path = path(from, segments)

--- a/lib/plug/static.ex
+++ b/lib/plug/static.ex
@@ -175,13 +175,13 @@ defmodule Plug.Static do
 
       if invalid_path?(segments) do
         Logger.error("Got invalid path: #{inspect(segments)}")
-        raise InvalidPathError, "invalid path for static asset: #{conn.request_path}"
+        conn
+      else
+        path = path(from, segments)
+        range = get_req_header(conn, "range")
+        encoding = file_encoding(conn, path, range, gzip?, brotli?)
+        serve_static(encoding, conn, segments, range, options)
       end
-
-      path = path(from, segments)
-      range = get_req_header(conn, "range")
-      encoding = file_encoding(conn, path, range, gzip?, brotli?)
-      serve_static(encoding, conn, segments, range, options)
     else
       conn
     end


### PR DESCRIPTION
The path traversal issue involved the NMC allowing GET requests for paths that were outside the directory for static resources on the NMC. The plug module actually does check for path traversal patterns, but some time ago, the exception that was raised as a result of an invalid file path was removed in favour of a Logger error instead. 

The issue with this is that while it still flagged the invalid file path, it continued with serving the static resource at that path. 

This PR is to return the connection unchanged if the file path is invalid. If the exception that is used in the original repository is added back in, the user is presented with a Phoenix error page, as a result of a Bad Request error code being returned. With this change to returning the connection without acting, the request falls through to get redirected to the NMC's "Not found" page.